### PR TITLE
Intercept pipeline at Setup phase for XForwardedHeaderSupport feature…

### DIFF
--- a/ktor-server/ktor-server-core/jvm/src/io/ktor/features/OriginConnectionPoint.kt
+++ b/ktor-server/ktor-server-core/jvm/src/io/ktor/features/OriginConnectionPoint.kt
@@ -91,7 +91,7 @@ object XForwardedHeaderSupport : ApplicationFeature<ApplicationCallPipeline,
         val config = Config()
         configure(config)
 
-        pipeline.intercept(ApplicationCallPipeline.Features) {
+        pipeline.intercept(ApplicationCallPipeline.Setup) {
             call.forEachHeader(config.protoHeaders) { value ->
                 call.mutableOriginConnectionPoint.let { route ->
                     route.scheme = value
@@ -181,7 +181,7 @@ object ForwardedHeaderSupport : ApplicationFeature<ApplicationCallPipeline, Unit
     override fun install(pipeline: ApplicationCallPipeline, configure: Unit.() -> Unit) {
         configure(Unit)
 
-        pipeline.intercept(ApplicationCallPipeline.Features) {
+        pipeline.intercept(ApplicationCallPipeline.Setup) {
             val forwarded = call.request.forwarded()
             if (forwarded != null) {
                 call.attributes.put(ForwardedParsedKey, forwarded)


### PR DESCRIPTION
This is a change proposed in #680: change interception phase for `XForwardedHeaderSupport` to `Setup` so that `Monitoring` features can use rewritten call properties provided with `X-Forwarded-*` headers.

**Subsystem**
Ktor Server, core, features.

**Motivation**
See more context in #680.


